### PR TITLE
Add Custom Android device profile with user-facing world settings

### DIFF
--- a/android/app/src/main/java/chat/buku/skate3/BugReporter.java
+++ b/android/app/src/main/java/chat/buku/skate3/BugReporter.java
@@ -116,6 +116,7 @@ final class BugReporter {
                     int equals = line.indexOf('=');
                     if (equals >= 0) {
                         String value = line.substring(equals + 1).trim();
+                        if (value.startsWith("2")) return "Custom";
                         if (value.startsWith("1")) return "High-End / Quality";
                         if (value.startsWith("0")) return "RG406V / Performance";
                     }

--- a/src/skate3_app_common.cpp
+++ b/src/skate3_app_common.cpp
@@ -120,10 +120,39 @@ REXCVAR_DEFINE_DOUBLE(skate3_ultrawide_target_aspect, 0.0, "Skate 3",
 REXCVAR_DEFINE_INT32(
     skate3_android_quality_profile, 0, "Skate 3",
     "Android device profile: 0 = RG406V / Performance (288p and aggressive "
-    "scene cuts), 1 = High-End / Quality (720p and the full native material "
-    "pipeline). Applied after restart.")
-    .range(0, 1)
+    "scene cuts), 1 = High-End / Quality (720p, verified lean scene feature "
+    "set), 2 = Custom (user-controlled scene resolution, world detail and "
+    "renderer features; presets do not overwrite saved settings). Applied "
+    "after restart.")
+    .range(0, 2)
     .lifecycle(rex::cvar::Lifecycle::kRequiresRestart);
+// Custom-profile scene target caps, consumed by EnsureOutputSizedTargets in
+// skate3_native_scene_gpu.cpp. Only read while
+// skate3_android_quality_profile = 2 so the verified Performance/Quality
+// preset targets stay byte-identical. 0 = keep that profile's 1280x720 box.
+REXCVAR_DEFINE_INT32(skate3_android_scene_width_cap, 0, "Skate 3",
+                     "Custom profile: 3D scene target width cap in pixels "
+                     "(0 = 1280). Applies live; the scene target is rebuilt "
+                     "on the next frame.")
+    .range(0, 2560)
+    .lifecycle(rex::cvar::Lifecycle::kHotReload);
+REXCVAR_DEFINE_INT32(skate3_android_scene_height_cap, 540, "Skate 3",
+                     "Custom profile: 3D scene target height cap in pixels "
+                     "(0 = 720). Applies live; the scene target is rebuilt "
+                     "on the next frame.")
+    .range(0, 1440)
+    .lifecycle(rex::cvar::Lifecycle::kHotReload);
+// Android decodes BC textures to RGBA8 on the CPU (mobile GPUs expose no BC),
+// starting from the first guest mip at or below this size. 128 is the
+// verified handheld budget; each doubling quadruples a texture's resident
+// bytes against the tex_store_mb budget. Applies to textures as they are
+// (re)uploaded, so already-resident art sharpens as the world re-streams.
+REXCVAR_DEFINE_INT32(skate3_android_texture_size_cap, 128, "Skate 3",
+                     "Largest mip level (in pixels) Android decodes for "
+                     "compressed world/character textures. Higher is sharper "
+                     "and uses more memory and decode time.")
+    .range(64, 1024)
+    .lifecycle(rex::cvar::Lifecycle::kHotReload);
 #endif
 
 namespace {
@@ -684,8 +713,38 @@ void Skate3BaseApp::OnConfigurePaths(rex::PathConfig& paths) {
       {"skate3_native_render_scene_perf_interval", "300"},
       {"show_fps_counter", "false"},
   };
+  // Custom profile: pin only the internal pacing/stability cvars that have no
+  // user-facing row anywhere; every user-facing setting (handheld_potato,
+  // scene caps, MSAA, shadows, SSAO, bloom, volumetrics, lightmaps/macro/
+  // decals, draw distance, FPS counter, ...) is deliberately absent so the
+  // values loaded from the saved settings file survive this preset pass.
+  // When the user switches profiles in the menu, SaveSimpleSettingsConfig
+  // snapshots the then-active values, so Custom starts from the last-used
+  // preset's known-good feature set rather than desktop defaults.
+  constexpr std::pair<std::string_view, std::string_view> kCustomBasePreset[] = {
+      {"native_render_suppress_mode", "1"},
+      // guest_static_refresh and lw_update_refresh are deliberately absent:
+      // they are the Custom profile's user-facing World/NPC update pacing
+      // rows and load from the settings file.
+      {"skate3_native_render_scene_ssr", "false"},
+      {"skate3_native_render_scene_hdr", "false"},
+      {"skate3_native_render_scene_smooth_camera", "false"},
+      {"skate3_native_render_scene_selection_outline", "false"},
+      {"skate3_native_render_scene_sort_opaque", "false"},
+      {"skate3_native_render_scene_splines", "false"},
+      {"skate3_native_render_scene_ropa_blend", "false"},
+      {"skate3_native_render_scene_entity_fade", "false"},
+      {"skate3_native_render_scene_lw_fade", "false"},
+      {"skate3_native_render_scene_lw_gap_fill", "false"},
+      {"skate3_native_render_scene_lw_identity", "false"},
+      {"skate3_native_render_scene_lw_palette", "false"},
+      {"skate3_native_render_scene_prewarm_budget_ms", "8"},
+      {"skate3_native_render_scene_occlusion_cull", "true"},
+      {"skate3_native_render_scene_occlusion_cull_build", "true"},
+      {"skate3_native_render_scene_occlusion_cull_guest", "true"},
+  };
   const int32_t android_profile =
-      std::clamp(rex::cvar::Query<int32_t>("skate3_android_quality_profile"), 0, 1);
+      std::clamp(rex::cvar::Query<int32_t>("skate3_android_quality_profile"), 0, 2);
   const auto apply_profile = [](const auto& profile) {
     for (const auto& [name, value] : profile) {
       rex::cvar::SetFlagByName(std::string(name), std::string(value));
@@ -696,11 +755,22 @@ void Skate3BaseApp::OnConfigurePaths(rex::PathConfig& paths) {
     REXLOG_INFO(
         "Android device profile: RG406V / Performance (512x288, 0.5x "
         "world/LOD, simplified materials)");
-  } else {
+  } else if (android_profile == 1) {
     apply_profile(kHighEndPreset);
     REXLOG_INFO(
         "Android device profile: High-End / Quality compatibility baseline "
         "(1280x720 target, verified lean scene feature set)");
+  } else {
+    apply_profile(kCustomBasePreset);
+    REXLOG_INFO(
+        "Android device profile: Custom ({}x{} cap, user-controlled scene "
+        "features; saved settings preserved)",
+        rex::cvar::Query<int32_t>("skate3_android_scene_width_cap") > 0
+            ? rex::cvar::Query<int32_t>("skate3_android_scene_width_cap")
+            : 1280,
+        rex::cvar::Query<int32_t>("skate3_android_scene_height_cap") > 0
+            ? rex::cvar::Query<int32_t>("skate3_android_scene_height_cap")
+            : 720);
   }
 #endif
   Skate3InitializeFieldOfViewOverride();

--- a/src/skate3_native_render.cpp
+++ b/src/skate3_native_render.cpp
@@ -134,8 +134,11 @@ bool Enabled() { return REXCVAR_GET(skate3_native_render); }
 
 bool ShouldUpdateLivingWorld(uint32_t entity) {
 #if REX_PLATFORM_ANDROID
-  if (Enabled() && REXCVAR_GET(skate3_native_render_scene_handheld_potato) &&
-      !REXCVAR_GET(skate3_mp_enabled)) {
+  // Governed by skate3_native_render_lw_update_refresh alone (1 = every
+  // frame, i.e. original behavior). Not tied to handheld_potato: spreading
+  // ambient LivingWorld updates smooths crowd-induced frame spikes on any
+  // device, including ones running the full scene content.
+  if (Enabled() && !REXCVAR_GET(skate3_mp_enabled)) {
     const int32_t refresh =
         std::clamp(REXCVAR_GET(skate3_native_render_lw_update_refresh), 1, 8);
     if (refresh > 1) {
@@ -192,7 +195,12 @@ void OnSceneDrawList(uint8_t* base, uint32_t view, uint32_t sort_vec, uint32_t f
   // packet builder only needs to refresh them periodically; native capture
   // below still records the complete list on every frame.
 #if REX_PLATFORM_ANDROID
-  if (REXCVAR_GET(skate3_native_render_scene_handheld_potato)) {
+  // Governed by skate3_native_render_guest_static_refresh alone (1 = rebuild
+  // every frame, i.e. original behavior). Not tied to handheld_potato: the
+  // dynamic-context tracking below keeps animated draws refreshing every
+  // frame regardless of scene content, so replaying cached static lists is
+  // a content-independent CPU saving.
+  {
     const int32_t refresh =
         std::clamp(REXCVAR_GET(skate3_native_render_guest_static_refresh), 1, 16);
     if (refresh > 1 && (g_frame_index % uint64_t(refresh)) != 0) {

--- a/src/skate3_native_scene.cpp
+++ b/src/skate3_native_scene.cpp
@@ -1246,6 +1246,14 @@ REXCVAR_DEFINE_BOOL(
     "scene fidelity.")
     .lifecycle(rex::cvar::Lifecycle::kHotReload);
 
+REXCVAR_DEFINE_BOOL(
+    skate3_native_render_scene_ambient_npcs, true, "Skate 3",
+    "Draw ambient LivingWorld pedestrians and traffic. Off removes them at "
+    "scene capture, skipping their per-frame palette/world capture cost; "
+    "the player, other skaters and gameplay objects are unaffected and the "
+    "underlying simulation keeps running.")
+    .lifecycle(rex::cvar::Lifecycle::kHotReload);
+
 REXCVAR_DEFINE_INT32(skate3_native_render_scene_perf_interval, 600, "Skate 3",
                      "Frames between native-scene perf/stats log lines. Lower "
                      "values give finer windows for chasing transient frame-"
@@ -2752,6 +2760,14 @@ bool HandheldPotatoEnabled() {
 // publication for statics, so dropped content avoids the expensive scene
 // post-processing and render-side texture/draw work as well.
 bool HandheldPotatoDrops(const DrawItem& item) {
+  // Ambient pedestrians/traffic are a standalone user toggle, independent
+  // of the potato profile. Their simulation continues; only scene capture
+  // (and with it the per-frame palette/world capture cost) is skipped.
+  if ((item.char_family == 3 || item.char_family == 6 ||
+       item.char_family == 7) &&
+      !REXCVAR_GET(skate3_native_render_scene_ambient_npcs)) {
+    return true;
+  }
   if (!HandheldPotatoEnabled()) {
     return false;
   }

--- a/src/skate3_native_scene_gpu.cpp
+++ b/src/skate3_native_scene_gpu.cpp
@@ -81,6 +81,7 @@ REXCVAR_DECLARE(bool, skate3_native_render_scene_fmv_yield);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_hdr);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_hdr_packed);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_handheld_potato);
+REXCVAR_DECLARE(bool, skate3_native_render_scene_ambient_npcs);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_lightmaps);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_lm_dump);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_loading_native);
@@ -132,6 +133,9 @@ REXCVAR_DECLARE(bool, skate3_native_render_scene_ssao_full_res);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_ssr);
 #if REX_PLATFORM_ANDROID
 REXCVAR_DECLARE(int32_t, skate3_android_quality_profile);
+REXCVAR_DECLARE(int32_t, skate3_android_scene_width_cap);
+REXCVAR_DECLARE(int32_t, skate3_android_scene_height_cap);
+REXCVAR_DECLARE(int32_t, skate3_android_texture_size_cap);
 #endif
 REXCVAR_DECLARE(bool, skate3_native_render_scene_tex_mips);
 REXCVAR_DECLARE(bool, skate3_native_render_scene_tex_revalidate);
@@ -1746,18 +1750,24 @@ bool EnsureGuestTextureFromWords(const NativeGuestOutputRenderContext& context,
 #else
   const bool mobile_bc = false;
 #endif
-  // Mobile BC->RGBA expansion is intentionally quality-capped. Select an
-  // existing guest mip instead of decoding and then downsampling the large
-  // top levels. This keeps the worker cost and resident memory bounded.
+  // Mobile BC->RGBA expansion is quality-capped. Select an existing guest
+  // mip instead of decoding and then downsampling the large top levels. This
+  // keeps the worker cost and resident memory bounded. The cap is a cvar so
+  // devices with memory headroom can trade RGBA8 bytes for sharp art; each
+  // doubling quadruples that texture's resident size (128^2 RGBA8 = 64 KB,
+  // 512^2 = 1 MB) against the tex_store_mb budget.
   uint32_t first_mip = 0;
-  constexpr uint32_t kMobileTextureMax = 128;
+#if REX_PLATFORM_ANDROID
+  const uint32_t mobile_texture_max = uint32_t(
+      std::clamp(REXCVAR_GET(skate3_android_texture_size_cap), 64, 1024));
   if (mobile_bc) {
     while (first_mip + 1 < mip_count &&
-           (std::max(width >> first_mip, 1u) > kMobileTextureMax ||
-            std::max(height >> first_mip, 1u) > kMobileTextureMax)) {
+           (std::max(width >> first_mip, 1u) > mobile_texture_max ||
+            std::max(height >> first_mip, 1u) > mobile_texture_max)) {
       ++first_mip;
     }
   }
+#endif
   // No guest chain at all (runtime-composed lightmap pages): generate one,
   // see UploadGeneratedMips. Small DXT1/8888 textures only; falls back to
   // the plain single-mip path on any failure.
@@ -4316,11 +4326,24 @@ bool EnsureOutputSizedTargets(const NativeGuestOutputRenderContext& context) {
   // Keep the 3D target proportional to the selected native output shape.
   // The RG406V profile retains its 288-line low-power budget (384x288 at
   // 4:3); the high-end profile renders at the full 720-line output
-  // (960x720 at 4:3).
-  const bool high_end_profile =
-      std::clamp(REXCVAR_GET(skate3_android_quality_profile), 0, 1) == 1;
-  const uint32_t width_cap = high_end_profile ? 1280u : 512u;
-  const uint32_t height_cap = high_end_profile ? 720u : 288u;
+  // (960x720 at 4:3). The custom profile reads its caps from the hot-reload
+  // scene-cap cvars (0 = fall back to the 1280x720 box); the dimension
+  // comparison below rebuilds the targets on the next frame after a change.
+  const int32_t android_profile =
+      std::clamp(REXCVAR_GET(skate3_android_quality_profile), 0, 2);
+  uint32_t width_cap = android_profile >= 1 ? 1280u : 512u;
+  uint32_t height_cap = android_profile >= 1 ? 720u : 288u;
+  if (android_profile == 2) {
+    const int32_t custom_width_cap = REXCVAR_GET(skate3_android_scene_width_cap);
+    const int32_t custom_height_cap =
+        REXCVAR_GET(skate3_android_scene_height_cap);
+    if (custom_width_cap > 0) {
+      width_cap = uint32_t(std::clamp(custom_width_cap, 2, 2560));
+    }
+    if (custom_height_cap > 0) {
+      height_cap = uint32_t(std::clamp(custom_height_cap, 2, 1440));
+    }
+  }
   uint32_t height = std::min(context.guest_output_height, height_cap);
   uint32_t width = uint32_t((uint64_t(height) * context.guest_output_width +
                              context.guest_output_height / 2) /
@@ -4954,12 +4977,20 @@ void ProcessPrewarmEntry(uint8_t* base, const PrewarmEntry& e) {
     }
     return;
   }
-  if (REXCVAR_GET(skate3_native_render_scene_handheld_potato)) {
-    const bool drop = item.env_family == 7 || item.env_family == 9 ||
-                      item.env_family == 10 || item.transparent ||
-                      item.env_family == 13 || item.char_family == 3 ||
-                      item.char_family == 6 || item.char_family == 7 ||
-                      item.dynobj != 0;
+  {
+    // Mirrors HandheldPotatoDrops: the potato content cuts, plus the
+    // standalone ambient pedestrians/traffic toggle.
+    const bool potato_on =
+        REXCVAR_GET(skate3_native_render_scene_handheld_potato);
+    const bool ambient_char = item.char_family == 3 ||
+                              item.char_family == 6 || item.char_family == 7;
+    const bool drop =
+        (potato_on &&
+         (item.env_family == 7 || item.env_family == 9 ||
+          item.env_family == 10 || item.transparent ||
+          item.env_family == 13 || ambient_char || item.dynobj != 0)) ||
+        (ambient_char &&
+         !REXCVAR_GET(skate3_native_render_scene_ambient_npcs));
     if (drop) {
       // Count this registration as completed without allocating any GPU
       // buffers or staging textures. The live capture/build path applies
@@ -4970,7 +5001,7 @@ void ProcessPrewarmEntry(uint8_t* base, const PrewarmEntry& e) {
       g_prewarm_out.push_back(std::move(res));
       return;
     }
-    if (item.char_family == 0 && !item.water) {
+    if (potato_on && item.char_family == 0 && !item.water) {
       item.lightmap_tex = 0;
       item.macro_tex = 0;
       item.detail_tex = 0;
@@ -12214,11 +12245,15 @@ void ResetSceneFailure() {
 void Install() {
 #if REX_PLATFORM_ANDROID
   // The app layer applies the selected Android profile after loading saved
-  // settings. Keep the native renderer mandatory on both profiles. Apply the
+  // settings. Keep the native renderer mandatory on all profiles. Apply the
   // conservative duplicate guard whenever the active scene preset is lean,
   // including QA builds that test the Quality resolution with lean features.
+  // The Custom profile (2) is exempt: there handheld_potato and the feature
+  // cvars below are independent user settings, and this blanket force-off
+  // would silently defeat the saved values loaded before this point.
   REXCVAR_SET(skate3_native_render_scene, true);
-  if (REXCVAR_GET(skate3_native_render_scene_handheld_potato)) {
+  if (std::clamp(REXCVAR_GET(skate3_android_quality_profile), 0, 2) != 2 &&
+      REXCVAR_GET(skate3_native_render_scene_handheld_potato)) {
     REXCVAR_SET(skate3_native_render_scene_handheld_potato, true);
     REXCVAR_SET(skate3_native_render_scene_msaa, 1);
     REXCVAR_SET(skate3_native_render_scene_shadows, false);


### PR DESCRIPTION
skate3_android_quality_profile gains value 2 (Custom). Unlike the RG406V/Performance and High-End/Quality presets, Custom applies only the internal stability baseline and preserves every user-facing setting loaded from the settings file, so the existing Video menu rows (MSAA, shadows, SSAO, bloom, draw distance, ...) finally persist across restarts instead of being overwritten at boot. Both existing presets are byte-for-byte unchanged and remain the verified handheld baselines.

New hot-reload cvars, all defaulting to current behavior:
- skate3_android_scene_width_cap / skate3_android_scene_height_cap: Custom-profile 3D scene target caps (default 960x540 box), consumed by EnsureOutputSizedTargets only when profile 2 is active.
- skate3_android_texture_size_cap: largest mip the mobile BC->RGBA expansion decodes (default 128, the previous hardcoded cap). Devices with memory headroom can trade RGBA8 bytes for sharp world/character art against the existing tex_store budget.
- skate3_native_render_scene_ambient_npcs: standalone pedestrians and traffic toggle, dropped at scene capture like the potato path does; simulation keeps running, player/skaters/mission objects unaffected. Mirrored in the prewarm worker classification.

LivingWorld update spreading (lw_update_refresh) and the guest static draw-list pacing (guest_static_refresh) now follow their cvars alone instead of being additionally gated on handheld_potato; both presets pin the previous values, so preset behavior is identical, while the Custom profile exposes them as NPC/World Update Rate settings.

Install()'s lean-feature force is skipped for profile 2 so saved feature settings survive boot, and BugReporter reports the Custom profile.

Submodule: rexglue-sdk picks up the matching settings-overlay rows.